### PR TITLE
Clear os-api-cache when updating package

### DIFF
--- a/os_package_registry/package_registry.py
+++ b/os_package_registry/package_registry.py
@@ -163,8 +163,11 @@ class PackageRegistry(object):
                        body=body, id=name)
         # Make sure that the data is saved
         self.es.indices.flush(self.index_name)
-        # Clear the api cache
-        api_cache.clear(name)
+        # Clear the api cache (if api_cache isn't None)
+        try:
+            api_cache.clear(name)
+        except AttributeError:
+            pass
 
     def delete_model(self, name):
         """

--- a/os_package_registry/package_registry.py
+++ b/os_package_registry/package_registry.py
@@ -4,6 +4,10 @@ from collections import namedtuple
 
 from elasticsearch import Elasticsearch, NotFoundError
 
+from os_api_cache import get_os_cache
+
+api_cache = get_os_cache()
+
 
 class PackageRegistry(object):
 
@@ -159,6 +163,8 @@ class PackageRegistry(object):
                        body=body, id=name)
         # Make sure that the data is saved
         self.es.indices.flush(self.index_name)
+        # Clear the api cache
+        api_cache.clear(name)
 
     def delete_model(self, name):
         """

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
 
         'License :: OSI Approved :: MIT License',
 
-        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
     ],
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='os-package-registry',
-    version='0.0.14',
+    version='0.0.15',
     description=(
         'Manage a registry of packages on an ElasticSearch instance'
     ),

--- a/setup.py
+++ b/setup.py
@@ -42,5 +42,6 @@ setup(
 
     install_requires=[
         'elasticsearch>=1.0.0,<2.0.0',
+        'os-api-cache>=0.0.6'
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -10,12 +10,12 @@ with open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='os-package-registry',
-    version='0.0.13',
+    version='0.0.14',
     description=(
         'Manage a registry of packages on an ElasticSearch instance'
     ),
     long_description=long_description,
-
+    long_description_content_type="text/markdown",
     url='https://github.com/openspending/os-package-registry',
 
     author='Open Knowledge International',


### PR DESCRIPTION
Adds os-api-cache dependency to use the `.clear()` method to ensure package items are up to date after updating.

Fixes openspending/openspending#1377.