### PR TITLE
Update elasticsearch to 5.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
 
 before_install:
   - sudo rm -f /etc/boto.cfg
-  - curl -O https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.5.2.deb && sudo dpkg -i --force-confnew elasticsearch-1.5.2.deb && sudo service elasticsearch restart
+  - curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.11.deb && sudo dpkg -i --force-confnew elasticsearch-5.6.11.deb && sudo service elasticsearch restart
 
 install:
   - pip install tox coveralls

--- a/os_package_registry/package_registry.py
+++ b/os_package_registry/package_registry.py
@@ -44,6 +44,14 @@ class PackageRegistry(object):
                     "type": "string",
                     "index": "not_analyzed",
                 },
+                'countryCode': {
+                    'type': 'text',
+                    'fields': {
+                        'keyword': {
+                           'type': 'keyword'
+                        }
+                    }
+                },
                 'resources': {
                     "type": "object",
                     "properties": {
@@ -246,12 +254,12 @@ class PackageRegistry(object):
                     },
                     'num_records': {
                         'sum': {
-                            'field': 'count_of_rows',
+                            'field': 'package.count_of_rows',
                         },
                     },
                     'num_countries': {
                         'cardinality': {
-                            'field': 'countryCode',
+                            'field': 'package.countryCode.keyword',
                         },
                     },
                 },

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     packages=find_packages(exclude=['tests']),
 
     install_requires=[
-        'elasticsearch>=1.0.0,<2.0.0',
+        'elasticsearch>=5.0.0,<6.0.0',
         'os-api-cache>=0.0.7'
     ],
 )


### PR DESCRIPTION
This PR allows os-package-registry to use ES 5.x.

Part of https://github.com/okfn/devops/issues/120/