### PR TITLE
Replace model and package properties during update.

### DIFF
--- a/os_package_registry/package_registry.py
+++ b/os_package_registry/package_registry.py
@@ -146,6 +146,21 @@ class PackageRegistry(object):
         :param loaded: Was the package loaded successfully
         """
 
+        # If `model` or `datapackage` in kw args, completely remove respective
+        # field from the ES item, so it can be replaced below (rather than
+        # merged).
+        if 'model' in kw:
+            body_remove_model = \
+                '{"script" : "ctx._source.remove(\u0027model\u0027)"}'
+            self.es.update(index=self.index_name, doc_type=self.DOC_TYPE,
+                           body=body_remove_model, id=name)
+
+        if 'datapackage' in kw:
+            body_remove_datapackage = \
+                '{"script" : "ctx._source.remove(\u0027package\u0027)"}'
+            self.es.update(index=self.index_name, doc_type=self.DOC_TYPE,
+                           body=body_remove_datapackage, id=name)
+
         document = {
             'id': name,
             'last_update': time.time()

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -93,7 +93,7 @@ class TestPackageRegistry(object):
         dp = {'name': 'moses'}
         model = {'my-model': 'is-great'}
         dataset_name = 'ds-name'
-        author = 'authors-name' 
+        author = 'authors-name'
         status = 'FUNKY'
         loaded = False
 
@@ -123,4 +123,16 @@ class TestPackageRegistry(object):
         status = 'AWESOME'
         loaded = True
         package_registry.update_model(name, status=status, loaded=loaded)
+        check()
+
+        # Update existing property of model
+        model = {'my-model': 'replace model'}
+        dp = {'name': 'replace name'}
+        package_registry.update_model(name, model=model, datapackage=dp)
+        check()
+
+        # Replace model
+        model = {'completely': 'replace model'}
+        dp = {'completely': 'replace dp'}
+        package_registry.update_model(name, model=model, datapackage=dp)
         check()


### PR DESCRIPTION
If model and/or package objects are passed to `update_model`, first remove the respective properties from the Elasticsearch item, then update with the new objects. This prevents these objects being merged into existing objects, which can cause errors in the viewer and out of date data being returned from os api calls.

Fixes openspending/openspending#1403